### PR TITLE
Fix hero banner - Mar 31, 2026

### DIFF
--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -197,6 +197,26 @@ function detectMarquee(block) {
 }
 
 /**
+ * Unwraps orphaned <p> wrappers that contain block-level elements.
+ * aem.js wrapTextNodes() wraps all cell children in a single <p> when the
+ * first child is a <picture> with siblings. After the image is extracted to
+ * hero-bg, this <p> traps headings and nested <p> elements inside it,
+ * breaking flex layout on banners. This helper promotes those children back
+ * to direct children of the container.
+ * @param {Element} container The hero-content element
+ */
+function unwrapBlockElements(container) {
+  [...container.querySelectorAll(':scope > p')].forEach((p) => {
+    if (p.querySelector('h1, h2, h3, h4, h5, h6')) {
+      while (p.firstChild) {
+        p.parentNode.insertBefore(p.firstChild, p);
+      }
+      p.remove();
+    }
+  });
+}
+
+/**
  * Rebuilds the block DOM with background image, content overlay, and disclaimer.
  * @param {Element} block The hero block element
  * @param {Element|null} imgEl The image or picture element
@@ -227,6 +247,10 @@ function rebuildBlock(block, imgEl, content, disclaimer, isBanner) {
     content.classList.add('hero-content');
     block.append(content);
   }
+
+  // Fix orphaned <p> wrappers from wrapTextNodes (see unwrapBlockElements)
+  const heroContent = block.querySelector('.hero-content');
+  if (heroContent) unwrapBlockElements(heroContent);
 
   if (disclaimer) {
     disclaimer.classList.add('hero-disclaimer');


### PR DESCRIPTION
Automated migration updates generated by Experience Modernization Agent.

Changed files (1):
- blocks/hero/hero.js

## Test URLs:

**card**
- Before: https://headernav--summit-vzn--aemdemos.aem.page/docs/library/blocks/card.plain
- After: https://aem-20260331-1102--summit-vzn--aemdemos.aem.page/docs/library/blocks/card.plain

**cards**
- Before: https://headernav--summit-vzn--aemdemos.aem.page/docs/library/blocks/cards.plain
- After: https://aem-20260331-1102--summit-vzn--aemdemos.aem.page/docs/library/blocks/cards.plain

**footer**
- Before: https://headernav--summit-vzn--aemdemos.aem.page/docs/library/blocks/footer.plain
- After: https://aem-20260331-1102--summit-vzn--aemdemos.aem.page/docs/library/blocks/footer.plain

**header**
- Before: https://headernav--summit-vzn--aemdemos.aem.page/docs/library/blocks/header.plain
- After: https://aem-20260331-1102--summit-vzn--aemdemos.aem.page/docs/library/blocks/header.plain

**hero**
- Before: https://headernav--summit-vzn--aemdemos.aem.page/docs/library/blocks/hero.plain
- After: https://aem-20260331-1102--summit-vzn--aemdemos.aem.page/docs/library/blocks/hero.plain

**quicklinks**
- Before: https://headernav--summit-vzn--aemdemos.aem.page/docs/library/blocks/quicklinks.plain
- After: https://aem-20260331-1102--summit-vzn--aemdemos.aem.page/docs/library/blocks/quicklinks.plain

**search**
- Before: https://headernav--summit-vzn--aemdemos.aem.page/docs/library/blocks/search.plain
- After: https://aem-20260331-1102--summit-vzn--aemdemos.aem.page/docs/library/blocks/search.plain

**footer**
- Before: https://headernav--summit-vzn--aemdemos.aem.page/footer.plain
- After: https://aem-20260331-1102--summit-vzn--aemdemos.aem.page/footer.plain

**index**
- Before: https://headernav--summit-vzn--aemdemos.aem.page/index.plain
- After: https://aem-20260331-1102--summit-vzn--aemdemos.aem.page/index.plain

**nav**
- Before: https://headernav--summit-vzn--aemdemos.aem.page/nav.plain
- After: https://aem-20260331-1102--summit-vzn--aemdemos.aem.page/nav.plain

**search**
- Before: https://headernav--summit-vzn--aemdemos.aem.page/search.plain
- After: https://aem-20260331-1102--summit-vzn--aemdemos.aem.page/search.plain

