### PR TITLE
Fix hero banner again - Mar 31, 2026

### DIFF
--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -197,17 +197,22 @@ function detectMarquee(block) {
 }
 
 /**
- * Unwraps orphaned <p> wrappers that contain block-level elements.
- * aem.js wrapTextNodes() wraps all cell children in a single <p> when the
- * first child is a <picture> with siblings. After the image is extracted to
- * hero-bg, this <p> traps headings and nested <p> elements inside it,
- * breaking flex layout on banners. This helper promotes those children back
- * to direct children of the container.
+ * Cleans up hero-content after the image is extracted to hero-bg.
+ *
+ * Two scenarios handled:
+ * 1. AEM-delivered content: the image was in its own <p>, leaving an empty
+ *    <p> after extraction. Remove it so it doesn't become a stray flex child.
+ * 2. Local .plain.html: wrapTextNodes() wrapped all cell children in a single
+ *    <p>. After image extraction this <p> traps headings and nested <p>
+ *    elements, breaking flex layout. Unwrap those children.
+ *
  * @param {Element} container The hero-content element
  */
-function unwrapBlockElements(container) {
+function cleanupContent(container) {
   [...container.querySelectorAll(':scope > p')].forEach((p) => {
-    if (p.querySelector('h1, h2, h3, h4, h5, h6')) {
+    if (!p.textContent.trim() && !p.querySelector('img, picture, a')) {
+      p.remove();
+    } else if (p.querySelector('h1, h2, h3, h4, h5, h6')) {
       while (p.firstChild) {
         p.parentNode.insertBefore(p.firstChild, p);
       }
@@ -248,9 +253,9 @@ function rebuildBlock(block, imgEl, content, disclaimer, isBanner) {
     block.append(content);
   }
 
-  // Fix orphaned <p> wrappers from wrapTextNodes (see unwrapBlockElements)
+  // Clean up empty <p> and orphaned wrappers left after image extraction
   const heroContent = block.querySelector('.hero-content');
-  if (heroContent) unwrapBlockElements(heroContent);
+  if (heroContent) cleanupContent(heroContent);
 
   if (disclaimer) {
     disclaimer.classList.add('hero-disclaimer');


### PR DESCRIPTION
Automated migration updates generated by Experience Modernization Agent.

Changed files (1):
- blocks/hero/hero.js

## Test URLs:

**card**
- Before: https://aem-20260331-1102--summit-vzn--aemdemos.aem.page/docs/library/blocks/card.plain
- After: https://aem-20260331-1109--summit-vzn--aemdemos.aem.page/docs/library/blocks/card.plain

**cards**
- Before: https://aem-20260331-1102--summit-vzn--aemdemos.aem.page/docs/library/blocks/cards.plain
- After: https://aem-20260331-1109--summit-vzn--aemdemos.aem.page/docs/library/blocks/cards.plain

**footer**
- Before: https://aem-20260331-1102--summit-vzn--aemdemos.aem.page/docs/library/blocks/footer.plain
- After: https://aem-20260331-1109--summit-vzn--aemdemos.aem.page/docs/library/blocks/footer.plain

**header**
- Before: https://aem-20260331-1102--summit-vzn--aemdemos.aem.page/docs/library/blocks/header.plain
- After: https://aem-20260331-1109--summit-vzn--aemdemos.aem.page/docs/library/blocks/header.plain

**hero**
- Before: https://aem-20260331-1102--summit-vzn--aemdemos.aem.page/docs/library/blocks/hero.plain
- After: https://aem-20260331-1109--summit-vzn--aemdemos.aem.page/docs/library/blocks/hero.plain

**quicklinks**
- Before: https://aem-20260331-1102--summit-vzn--aemdemos.aem.page/docs/library/blocks/quicklinks.plain
- After: https://aem-20260331-1109--summit-vzn--aemdemos.aem.page/docs/library/blocks/quicklinks.plain

**search**
- Before: https://aem-20260331-1102--summit-vzn--aemdemos.aem.page/docs/library/blocks/search.plain
- After: https://aem-20260331-1109--summit-vzn--aemdemos.aem.page/docs/library/blocks/search.plain

**footer**
- Before: https://aem-20260331-1102--summit-vzn--aemdemos.aem.page/footer.plain
- After: https://aem-20260331-1109--summit-vzn--aemdemos.aem.page/footer.plain

**index**
- Before: https://aem-20260331-1102--summit-vzn--aemdemos.aem.page/index.plain
- After: https://aem-20260331-1109--summit-vzn--aemdemos.aem.page/index.plain

**nav**
- Before: https://aem-20260331-1102--summit-vzn--aemdemos.aem.page/nav.plain
- After: https://aem-20260331-1109--summit-vzn--aemdemos.aem.page/nav.plain

**search**
- Before: https://aem-20260331-1102--summit-vzn--aemdemos.aem.page/search.plain
- After: https://aem-20260331-1109--summit-vzn--aemdemos.aem.page/search.plain

